### PR TITLE
Create 6.gitignore

### DIFF
--- a/6.gitignore
+++ b/6.gitignore
@@ -1,0 +1,18 @@
+# Build and Release Folders
+bin-debug/
+bin-release/
+[Oo]bj/
+[Bb]in/
+
+# Other files and folders
+.settings/
+
+# Executables
+*.swf
+*.air
+*.ipa
+*.apk
+
+# Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
+# should NOT be excluded as they contain compiler settings and other important
+# information for Eclipse / Flash Builder.


### PR DESCRIPTION
This pull request includes changes to the `.gitignore` file to exclude various build, release, and other non-essential files and folders. The most important changes include the following additions:

* Excluded build and release folders such as `bin-debug/`, `bin-release/`, `[Oo]bj/`, and `[Bb]in/`.
* Excluded settings folder `.settings/`.
* Excluded executable files with extensions `.swf`, `.air`, `.ipa`, and `.apk`.
* Added a comment to clarify that project files like `.project`, `.actionScriptProperties`, and `.flexProperties` should not be excluded.